### PR TITLE
Fixed .sf2 extension

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,8 +14,8 @@ class _MyAppState extends State<MyApp> {
   @override
   initState() {
     FlutterMidi.unmute();
-    rootBundle.load("assets/sounds/Piano.SF2").then((sf2) {
-      FlutterMidi.prepare(sf2: sf2, name: "Piano.SF2");
+    rootBundle.load("assets/sounds/Piano.sf2").then((sf2) {
+      FlutterMidi.prepare(sf2: sf2, name: "Piano.sf2");
     });
     super.initState();
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,13 +81,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.0+1"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.4.0"
   quiver:
     dependency: transitive
     description:
@@ -106,7 +99,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.4"
+    version: "1.4.1"
   stack_trace:
     dependency: transitive
     description:
@@ -134,14 +127,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.0.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.2"
+    version: "0.2.1"
   tonic:
     dependency: "direct main"
     description:
@@ -164,5 +157,5 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.1.0 <3.0.0"
+  dart: ">=2.0.0 <3.0.0"
   flutter: ">=0.1.4 <2.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -81,6 +81,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.5.0+1"
+  pedantic:
+    dependency: transitive
+    description:
+      name: pedantic
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.0"
   quiver:
     dependency: transitive
     description:
@@ -99,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.4"
   stack_trace:
     dependency: transitive
     description:
@@ -127,14 +134,14 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.2"
   tonic:
     dependency: "direct main"
     description:
@@ -157,5 +164,5 @@ packages:
     source: hosted
     version: "2.0.8"
 sdks:
-  dart: ">=2.0.0 <3.0.0"
+  dart: ">=2.1.0 <3.0.0"
   flutter: ">=0.1.4 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,4 +22,4 @@ flutter:
   uses-material-design: true
 
   assets:
-   - assets/sounds/Piano.SF2
+   - assets/sounds/Piano.sf2


### PR DESCRIPTION
In both `main.dart` & `pubspec.yaml` files, the file `assets/sounds/Piano.sf2`, the file extension is in capital letters.